### PR TITLE
送金画面を携帯に対応させる

### DIFF
--- a/src/components/Send.js
+++ b/src/components/Send.js
@@ -62,18 +62,18 @@ const styles = theme => ({
 });
 const Send = (props) =>{
   const { classes } = props;
-  const errEmpMes="入力されていません";
-  const errNumMes="半角数字のみ入力してください";
-  const isTablet=(window.innerWidth <= 1024);
+  const ERR_EMPTY_MESSAGE="入力されていません";
+  const ERR_NUMBER_MESSAGE="半角数字のみ入力してください";
+  const IS_TABLET=(window.innerWidth <= 1024);
   return (
-    <div className={isTablet?classes.sendForm:null}>
+    <div className={IS_TABLET?classes.sendForm:null}>
       <form
         noValidate
         autoComplete="off"
 				onSubmit={e=>{props.sendSubmit(e)}}
       >
         <div>
-          <TextField　className={isTablet?classes.textFieldApp:classes.textFieldWeb}
+          <TextField　className={IS_TABLET?classes.textFieldApp:classes.textFieldWeb}
             label="送金金額"
             id="sendMoney"
             name="sendMoney"
@@ -81,13 +81,13 @@ const Send = (props) =>{
             onChange={e=>{props.handleChange(e)}}
             InputLabelProps={{error: false}}
             value={props.sendMoney}
-            helperText={props.errorEmptyMoney? errEmpMes : (props.errorMoney? errNumMes :"")}
+            helperText={props.errorEmptyMoney? ERR_EMPTY_MESSAGE : (props.errorMoney? ERR_NUMBER_MESSAGE :"")}
           />
         </div>
         {!(props.errorEmptyMoney||props.errorMoney)?<br/>:null}
         <br/>
         <div>
-          <TextField className={isTablet?classes.textFieldApp:classes.textFieldWeb}
+          <TextField className={IS_TABLET?classes.textFieldApp:classes.textFieldWeb}
             label="送り先 学籍番号"
             id="studentNum"
             name="studentNum"
@@ -95,7 +95,7 @@ const Send = (props) =>{
             onChange={e=>{props.handleChange(e)}}
             InputLabelProps={{error: false}}
             value={props.studentNum}
-            helperText={props.errorEmptyNum? errEmpMes : (props.errorNum? errNumMes :"")}
+            helperText={props.errorEmptyNum? ERR_EMPTY_MESSAGE : (props.errorNum? ERR_NUMBER_MESSAGE :"")}
           />
         </div>
         {!(props.errorEmptyNum||props.errorNum)?<br/>:null}
@@ -104,7 +104,7 @@ const Send = (props) =>{
           <Button
             variant="contained"
             color="primary"
-            className={isTablet?classes.submitButtonApp:classes.submitButtonWeb}
+            className={IS_TABLET?classes.submitButtonApp:classes.submitButtonWeb}
             type="submit"
           >
             send
@@ -117,7 +117,7 @@ const Send = (props) =>{
         open={props.submitModal}
         onClose={props.closeModal}
       >
-        <div className={isTablet?classes.paperApp:classes.paperWeb}>
+        <div className={IS_TABLET?classes.paperApp:classes.paperWeb}>
           <Typography variant="h6" id="modal-title">
             確認
           </Typography>


### PR DESCRIPTION
## 関連Issue
close #47 
## やったこと
画面の幅が1024以下の時、携帯用のデザインに変化するようにした
## 実装の詳細
window.innerWidthを使って画面の幅を取得した
取得した画面の幅をもとにスタイルが変わるようにした
画面のサイズが変わっても対応できるようにコンポーネントの幅を%で指定した
## レビューして欲しいところ
デザイン、コードに問題はないのかをレビューしてほしい。
750x1334, 320x480, 640x960の幅のみで検証したので他の幅では大丈夫か
## スクリーンショット
![screen shot 2018-11-25 at 15 23 59](https://user-images.githubusercontent.com/38876616/48976267-dce5b580-f0c7-11e8-8535-a5dfdca92b28.png)
![screen shot 2018-11-25 at 15 23 25](https://user-images.githubusercontent.com/38876616/48976268-dce5b580-f0c7-11e8-908d-573c02c01a5a.png)
![screen shot 2018-11-25 at 15 23 16](https://user-images.githubusercontent.com/38876616/48976269-dd7e4c00-f0c7-11e8-8f53-baa067a33dc6.png)
