### PR TITLE
サインイン画面　携帯版対応、iPad pro版対応

### DIFF
--- a/src/SignIn.css
+++ b/src/SignIn.css
@@ -95,8 +95,8 @@
     }
 
     .SignInFUNneyLogo {
-      width: 8em;
-      height: 8em;
+      width: 10em;
+      height: 10em;
     }
 
     .SignInFUNney {
@@ -104,7 +104,7 @@
       justify-content: center;
       align-items: center;
       margin-top: 5vh;
-      font-size: 220%;
+      font-size: 250%;
       font-family: cursive;
     }
 


### PR DESCRIPTION
## 関連Issue

feature/iss46
sign in画面 携帯用サイズ調整#46
close #46

## やったこと

sign in画面の横幅が0pxから765pxの時に携帯版のデザインを変更しました。
iPad Proの時は横幅1024pxまでの時サイズ変更しました。

## 実装の詳細

media screenを使って、画面の横幅に対応した携帯版のデザインを変更しました。
iPad proにも対応するように横幅を変更しました。

## レビューして欲しいところ

画面のlogoなどのサイズについてお願いします。

## スクリーンショット(あれば)

![2018-11-26 17 29 06](https://user-images.githubusercontent.com/29572313/49001880-45549580-f1a1-11e8-81d7-ed11ec927cd9.png)
