### PR TITLE
setting画面のスマホ版デザイン調整

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -59,6 +59,7 @@
   justify-content: center;
   align-items: center;
 }
+
 .Signout{
   width: 80%;
   width: calc((90vw - 230px));

--- a/src/App.css
+++ b/src/App.css
@@ -59,7 +59,6 @@
   justify-content: center;
   align-items: center;
 }
-
 .Signout{
   width: 80%;
   width: calc((90vw - 230px));

--- a/src/App.css
+++ b/src/App.css
@@ -55,8 +55,7 @@
 }
 
 .Setting{
-  margin-top: 8vh;
-  display: flex;
+  margin-top: 10vh;
   justify-content: center;
   align-items: center;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -55,11 +55,7 @@
 }
 
 .Setting{
-  width: 80%;
-  height: 70vh;
-  border: solid 1px black;
-  margin-top: 15vh;
-  margin-left: 10%;
+  margin-top: 8vh;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/SettingButton.css
+++ b/src/SettingButton.css
@@ -1,0 +1,4 @@
+.SignoutButton{
+  position: fixed;
+  bottom:10px;
+}

--- a/src/SettingButton.css
+++ b/src/SettingButton.css
@@ -1,11 +1,32 @@
+@media screen and (min-width:1025px) {
 .SignoutButton{
-  width:100vw;
-  position: fixed;
-  bottom:10px;
+  visibility:hidden;
+}
+
+.SettingForm{
+  width:40vw;
+  margin-top: 30vh;
+  margin-left: auto;
+  margin-right: auto;
+}
+}
+
+@media screen and (max-width:1024px) {
+.SettingBackground{
+  width: auto;
+  height: auto;
+  /* background-color: silver; */
+  }
+
+.SignoutButton{
+width:100vw;
+position: fixed;
+bottom:10px;
 }
 
 .SettingForm{
   width:80vw;
   position: fixed;
   margin-top: 30px
+}
 }

--- a/src/SettingButton.css
+++ b/src/SettingButton.css
@@ -1,4 +1,11 @@
 .SignoutButton{
+  width:100vw;
   position: fixed;
   bottom:10px;
+}
+
+.SettingForm{
+  width:80vw;
+  position: fixed;
+  margin-top: 30px
 }

--- a/src/SettingForm.css
+++ b/src/SettingForm.css
@@ -1,4 +1,0 @@
-.SignoutButton{
-  position: relative;
-  margin-top: 40vh;
-}

--- a/src/SettingForm.css
+++ b/src/SettingForm.css
@@ -1,0 +1,4 @@
+.SignoutButton{
+  position: relative;
+  margin-top: 40vh;
+}

--- a/src/components/SettingButton.js
+++ b/src/components/SettingButton.js
@@ -16,7 +16,7 @@ import '../SettingButton.css'
 const styles = theme => ({
   root: {
     width: '100%',
-    maxWidth: 340,
+    maxWidth: 360,
     backgroundColor: theme.palette.background.paper,
     margin:20,
   },

--- a/src/components/SettingButton.js
+++ b/src/components/SettingButton.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MenuList from '@material-ui/core/MenuList';
+import MenuItem from '@material-ui/core/MenuItem';
+import Paper from '@material-ui/core/Paper';
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListSubheader from "@material-ui/core/ListSubheader";
+import { withStyles } from '@material-ui/core/styles';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import UnarchiveIcon from '@material-ui/icons/Unarchive';
+
+const SettingButton=(props)=>{
+  const { classes } = props;
+  const styles = theme => ({
+    root: {
+      width: '100%',
+      maxWidth: 360,
+      backgroundColor: theme.palette.background.paper,
+      margin:10,
+    },
+    nested: {
+      paddingLeft: theme.spacing.unit * 4,
+    },
+  });
+
+  return(
+    <ListItem button>
+    <ListItemIcon>
+    <UnarchiveIcon/>
+    </ListItemIcon>
+    <ListItemText inset primary="Sign out" />
+
+    </ListItem>
+  )
+}
+
+SettingButton.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default (SettingButton);

--- a/src/components/SettingButton.js
+++ b/src/components/SettingButton.js
@@ -11,28 +11,38 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import UnarchiveIcon from '@material-ui/icons/Unarchive';
 
+import '../SettingButton.css'
+
+const styles = theme => ({
+  root: {
+    width: '100%',
+    maxWidth: 340,
+    backgroundColor: theme.palette.background.paper,
+    margin:20,
+  },
+  nested: {
+    paddingLeft: theme.spacing.unit * 2,
+  },
+});
+
 const SettingButton=(props)=>{
   const { classes } = props;
-  const styles = theme => ({
-    root: {
-      width: '100%',
-      maxWidth: 360,
-      backgroundColor: theme.palette.background.paper,
-      margin:10,
-    },
-    nested: {
-      paddingLeft: theme.spacing.unit * 4,
-    },
-  });
-
   return(
-    <ListItem button>
-    <ListItemIcon>
-    <UnarchiveIcon/>
-    </ListItemIcon>
-    <ListItemText inset primary="Sign out" />
-
-    </ListItem>
+    <div className="SignoutButton">
+      <ListItem button
+        onClick = {
+          e => {
+            props.clickTask()
+          }
+        }
+        className={classes.root}
+        >
+        <ListItemIcon>
+          <UnarchiveIcon/>
+        </ListItemIcon>
+        <ListItemText inset primary="Sign out" />
+      </ListItem>
+    </div>
   )
 }
 
@@ -40,4 +50,4 @@ SettingButton.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default (SettingButton);
+export default withStyles(styles)(SettingButton);

--- a/src/components/SettingForm.js
+++ b/src/components/SettingForm.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MenuList from '@material-ui/core/MenuList';
+import MenuItem from '@material-ui/core/MenuItem';
+import Paper from '@material-ui/core/Paper';
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListSubheader from "@material-ui/core/ListSubheader";
+import { withStyles } from '@material-ui/core/styles';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import InboxIcon from '@material-ui/icons/MoveToInbox';
+import DraftsIcon from '@material-ui/icons/Drafts';
+import BluetoothIcon from '@material-ui/icons/Bluetooth';
+
+const styles = theme => ({
+  root: {
+    width: '100%',
+    maxWidth: 360,
+    backgroundColor: theme.palette.background.paper,
+  },
+  nested: {
+    paddingLeft: theme.spacing.unit * 4,
+  },
+});
+
+const SettingForm=(props)=>{
+  const { classes } = props;
+  return(
+         <List
+           component="nav"
+           subheader={
+             <ListSubheader component="div">Account</ListSubheader>
+           }
+           className={classes.root}
+         >
+           <ListItem button>
+             <ListItemIcon>
+               <BluetoothIcon />
+             </ListItemIcon>
+             <ListItemText inset primary="個人情報" />
+           </ListItem>
+           <ListItem button>
+             <ListItemIcon>
+               <DraftsIcon />
+             </ListItemIcon>
+             <ListItemText inset primary="なんか" />
+           </ListItem>
+           <ListItem button>
+             <ListItemIcon>
+               <DraftsIcon />
+             </ListItemIcon>
+             <ListItemText inset primary="なんか" />
+           </ListItem>
+         </List>
+       );
+}
+SettingForm.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(SettingForm);

--- a/src/components/SettingForm.js
+++ b/src/components/SettingForm.js
@@ -10,14 +10,18 @@ import { withStyles } from '@material-ui/core/styles';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import InboxIcon from '@material-ui/icons/MoveToInbox';
-import DraftsIcon from '@material-ui/icons/Drafts';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import BluetoothIcon from '@material-ui/icons/Bluetooth';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+
+import '../SettingForm.css';
 
 const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
     backgroundColor: theme.palette.background.paper,
+    margin:10,
   },
   nested: {
     paddingLeft: theme.spacing.unit * 4,
@@ -26,34 +30,41 @@ const styles = theme => ({
 
 const SettingForm=(props)=>{
   const { classes } = props;
+
   return(
-         <List
-           component="nav"
-           subheader={
-             <ListSubheader component="div">Account</ListSubheader>
-           }
-           className={classes.root}
-         >
-           <ListItem button>
-             <ListItemIcon>
-               <BluetoothIcon />
-             </ListItemIcon>
-             <ListItemText inset primary="個人情報" />
-           </ListItem>
-           <ListItem button>
-             <ListItemIcon>
-               <DraftsIcon />
-             </ListItemIcon>
-             <ListItemText inset primary="なんか" />
-           </ListItem>
-           <ListItem button>
-             <ListItemIcon>
-               <DraftsIcon />
-             </ListItemIcon>
-             <ListItemText inset primary="なんか" />
-           </ListItem>
-         </List>
-       );
+    <List
+      component="nav"
+      subheader={
+        <ListSubheader component="div">Account</ListSubheader>
+      }
+      className={classes.root}
+      >
+      <ListItem button>
+        <ListItemIcon>
+          <AccountCircleIcon />
+        </ListItemIcon>
+        <ListItemText inset primary="個人情報" />
+      </ListItem>
+      <ListItem button>
+        <ListItemIcon>
+          <BluetoothIcon />
+        </ListItemIcon>
+        <ListItemText inset primary="なんか" />
+      </ListItem>
+      <ListItem button>
+        <ListItemIcon>
+          <MoreHorizIcon />
+        </ListItemIcon>
+        <ListItemText inset primary="なんか" />
+      </ListItem>
+      <ListItem button>
+        <ListItemIcon>
+          <MoreHorizIcon />
+        </ListItemIcon>
+        <ListItemText inset primary="more" />
+      </ListItem>
+    </List>
+  );
 }
 SettingForm.propTypes = {
   classes: PropTypes.object.isRequired,

--- a/src/components/SettingForm.js
+++ b/src/components/SettingForm.js
@@ -15,11 +15,12 @@ import BluetoothIcon from '@material-ui/icons/Bluetooth';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import Divider from '@material-ui/core/Divider';
 
+import '../SettingButton.css';
 
 const styles = theme => ({
   root: {
     width: '100%',
-    maxWidth: 310,
+    maxWidth: 360,
     backgroundColor: theme.palette.background.paper,
     margin:30,
   },
@@ -32,6 +33,7 @@ const SettingForm=(props)=>{
   const { classes } = props;
 
   return(
+    <div className="SettingForm">
     <List
       component="nav"
       subheader={
@@ -69,6 +71,7 @@ const SettingForm=(props)=>{
       </ListItem>
       <Divider />
     </List>
+  </div>
   );
 }
 

--- a/src/components/SettingForm.js
+++ b/src/components/SettingForm.js
@@ -13,15 +13,15 @@ import InboxIcon from '@material-ui/icons/MoveToInbox';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import BluetoothIcon from '@material-ui/icons/Bluetooth';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import Divider from '@material-ui/core/Divider';
 
-import '../SettingForm.css';
 
 const styles = theme => ({
   root: {
     width: '100%',
-    maxWidth: 360,
+    maxWidth: 310,
     backgroundColor: theme.palette.background.paper,
-    margin:10,
+    margin:30,
   },
   nested: {
     paddingLeft: theme.spacing.unit * 4,
@@ -39,33 +39,39 @@ const SettingForm=(props)=>{
       }
       className={classes.root}
       >
+      <Divider />
       <ListItem button>
-        <ListItemIcon>
-          <AccountCircleIcon />
+        <ListItemIcon >
+          <AccountCircleIcon/>
         </ListItemIcon>
-        <ListItemText inset primary="個人情報" />
+        <ListItemText inset primary="個人情報"/>
       </ListItem>
+      <Divider />
       <ListItem button>
         <ListItemIcon>
           <BluetoothIcon />
         </ListItemIcon>
-        <ListItemText inset primary="なんか" />
+        <ListItemText inset primary="none" />
       </ListItem>
+      <Divider />
       <ListItem button>
         <ListItemIcon>
           <MoreHorizIcon />
         </ListItemIcon>
-        <ListItemText inset primary="なんか" />
+        <ListItemText inset primary="none" />
       </ListItem>
+      <Divider />
       <ListItem button>
         <ListItemIcon>
           <MoreHorizIcon />
         </ListItemIcon>
         <ListItemText inset primary="more" />
       </ListItem>
+      <Divider />
     </List>
   );
 }
+
 SettingForm.propTypes = {
   classes: PropTypes.object.isRequired,
 };

--- a/src/containers/Setting.js
+++ b/src/containers/Setting.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
+import SettingForm from '../components/SettingForm.js'
 
 class Setting extends Component {
   render() {
     return (
       <div className="Setting">
-        Setting
+        <SettingForm/>
+
       </div>
     );
   }

--- a/src/containers/Setting.js
+++ b/src/containers/Setting.js
@@ -14,6 +14,7 @@ class Setting extends Component {
 
   render() {
     return (
+      <div className="SettingBackground">
       <div className="SettingForm">
         <SettingForm/>
         <SettingButton
@@ -23,6 +24,7 @@ class Setting extends Component {
             }
           }/>
       </div>
+    </div>
     );
   }
 }

--- a/src/containers/Setting.js
+++ b/src/containers/Setting.js
@@ -14,7 +14,7 @@ class Setting extends Component {
 
   render() {
     return (
-      <div className="Setting">
+      <div className="SettingForm">
         <SettingForm/>
         <SettingButton
           clickTask={

--- a/src/containers/Setting.js
+++ b/src/containers/Setting.js
@@ -4,18 +4,27 @@ import { withRouter } from 'react-router';
 import SettingButton from '../components/SettingButton.js';
 
 class Setting extends Component {
+  constructor(props) {
+    super(props);
+}
+
   changeLink() {
-    this.props.history.push('/Signout');
+    this.props.history.push("/");
   }
 
   render() {
     return (
       <div className="Setting">
         <SettingForm/>
-         <SettingButton/>
+        <SettingButton
+          clickTask={
+            e => {
+              this.changeLink(e)
+            }
+          }/>
       </div>
     );
   }
 }
 
-export default Setting;
+export default withRouter(Setting);

--- a/src/containers/Setting.js
+++ b/src/containers/Setting.js
@@ -1,12 +1,18 @@
 import React, { Component } from 'react';
 import SettingForm from '../components/SettingForm.js'
+import { withRouter } from 'react-router';
+import SettingButton from '../components/SettingButton.js';
 
 class Setting extends Component {
+  changeLink() {
+    this.props.history.push('/Signout');
+  }
+
   render() {
     return (
       <div className="Setting">
         <SettingForm/>
-
+         <SettingButton/>
       </div>
     );
   }


### PR DESCRIPTION
## feature/iss54

> setting画面 #54
> close#54

## やったこと

> デザインの調整とスマホ版にした時にサインアウトできるようにした。

## 実装の詳細

> スマホ版のsetting画面にsignoutボタンを追加し、singIn画面に遷移するようにした。

## レビューして欲しいところ

> デザイン全般とiPad版にした時のデザインについて確認してほしいです。

## スクリーンショット
![2019-01-07 15 49 23](https://user-images.githubusercontent.com/29572313/50753083-e2701700-1293-11e9-93d8-e9b3affab156.png)
