### PR TITLE
Home iPad Pro版のデザインカンプに沿って修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,7 +11,6 @@
   margin-left: 10%;
   display: flex;
   justify-content: center;
-  align-items: center;
 }
 
 .Send{

--- a/src/Home.css
+++ b/src/Home.css
@@ -1,10 +1,12 @@
 @media screen and (min-width:1025px) {
 .accountInformation {
   margin-top: 3vh;
+  width: 70vw;
 }
 
 .showInformation {
   display: flex;
+  justify-content: center;
 }
 
 .accountIcon {
@@ -18,7 +20,7 @@
 }
 
 .user {
-
+  font-size: 31px;
 }
 
 .space2 {
@@ -33,6 +35,7 @@
 @media screen and (min-width:768px) and ( max-width:1024px){
   .accountInformation {
     margin-top: 3vh;
+    width: 70vw;
   }
 
   .showInformation {
@@ -60,11 +63,16 @@
 
   .property {
   }
+
+  .space3 {
+    height: 10px;
+  }
 }
 
 @media screen and (max-width:767px) {
   .accountInformation {
     margin-top: 3vh;
+    width: 70vw;
   }
 
   .showInformation {
@@ -90,5 +98,6 @@
   }
 
   .property {
+
   }
 }

--- a/src/Home.css
+++ b/src/Home.css
@@ -1,5 +1,6 @@
+@media screen and (min-width:1025px) {
 .accountInformation {
-  margin-top: -55vh;
+  margin-top: 3vh;
 }
 
 .showInformation {
@@ -25,4 +26,69 @@
 }
 
 .property {
+}
+
+}
+
+@media screen and (min-width:768px) and ( max-width:1024px){
+  .accountInformation {
+    margin-top: 3vh;
+  }
+
+  .showInformation {
+    display: flex;
+    justify-content: center;
+  }
+
+  .accountIcon {
+    width: 2.5em;
+    height: 2.5em;
+    justify-content: center;
+  }
+
+  .space1 {
+    width: 10px;
+  }
+
+  .user {
+    font-size: 31px;
+  }
+
+  .space2 {
+    width: 70px;
+  }
+
+  .property {
+  }
+}
+
+@media screen and (max-width:767px) {
+  .accountInformation {
+    margin-top: 3vh;
+  }
+
+  .showInformation {
+    display: flex;
+  }
+
+  .accountIcon {
+    width: 2.5em;
+    height: 2.5em;
+    justify-content: center;
+  }
+
+  .space1 {
+    width: 10px;
+  }
+
+  .user {
+
+  }
+
+  .space2 {
+    width: 50px;
+  }
+
+  .property {
+  }
 }

--- a/src/components/HomeUserAndProperty.js
+++ b/src/components/HomeUserAndProperty.js
@@ -21,27 +21,27 @@ const HomeUserAndProperty=(props)=> {
 
   return (
     <div className="accountInformation">
-      <Paper className={classes.root} elevation={1}>
-        <div className="showInformation">
-          <div className="user">
-            <b>
-              User
-            </b>
-          </div>
-          <div className="space1" />
-          <Typography className="userName" variant="h4" component="h1">
-            <b>
-              {props.userID}       さん
-            </b>
-          </Typography>
-          <div className="space2" />
-          <Typography className="property" variant="h4" component="h1">
-            <b>
-              総資産&nbsp;&nbsp;{props.userProperty}&nbsp;&nbsp;FNY
-            </b>
-          </Typography>
+      <div className="showInformation">
+        <div className="user">
+          <b>
+            User
+          </b>
         </div>
-      </Paper>
+        <div className="space1" />
+        <Typography className="userName" variant="h4" component="h1">
+          <b>
+            {props.userID}       さん
+          </b>
+        </Typography>
+        <div className="space2" />
+        <Typography className="property" variant="h4" component="h1">
+          <b>
+            総資産&nbsp;&nbsp;{props.userProperty}&nbsp;&nbsp;FNY
+          </b>
+        </Typography>
+      </div>
+      <div className="space3" />
+      <hr size="4" color="orange"/>
     </div>
   );
 }

--- a/src/components/HomeUserAndProperty.js
+++ b/src/components/HomeUserAndProperty.js
@@ -12,6 +12,7 @@ const styles = theme => ({
     ...theme.mixins.gutters(),
     paddingTop: theme.spacing.unit * 2,
     paddingBottom: theme.spacing.unit * 2,
+    width: "70vw",
   },
 });
 
@@ -22,11 +23,23 @@ const HomeUserAndProperty=(props)=> {
     <div className="accountInformation">
       <Paper className={classes.root} elevation={1}>
         <div className="showInformation">
-          <img className="accountIcon" src={AccountIcon} alt="logo" />
+          <div className="user">
+            <b>
+              User
+            </b>
+          </div>
           <div className="space1" />
-          <Typography className="user" variant="h4" component="h1">{props.userID}       さん</Typography>
+          <Typography className="userName" variant="h4" component="h1">
+            <b>
+              {props.userID}       さん
+            </b>
+          </Typography>
           <div className="space2" />
-          <Typography className="property" variant="h4" component="h1"> 総資産額     {props.userProperty}  FUNney</Typography>
+          <Typography className="property" variant="h4" component="h1">
+            <b>
+              総資産&nbsp;&nbsp;{props.userProperty}&nbsp;&nbsp;FNY
+            </b>
+          </Typography>
         </div>
       </Paper>
     </div>

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -10,7 +10,7 @@ class Home extends Component {
   constructor(props){
     super(props);
     this.state={
-      user:"Tatsuki Ikai",
+      user:"",
       property:100,
     }
   }


### PR DESCRIPTION
## 関連Issue
> Feature/iss76
> Home画面
> close#76

## やったこと
> Home画面をiPad Pro版のデザインカンプに沿って修正した

## 実装の詳細
> media screenを使用して、iPad Pro版のデザインカンプに沿って修正した。

## レビューして欲しいところ
> Homeの携帯版のデザインは、現在とてもひどい状態になっているので悪しからず。

## スクリーンショット
<img width="517" alt="2019-01-17 22 55 38" src="https://user-images.githubusercontent.com/38876832/51323279-11b03080-1aab-11e9-81ff-caad85796b8f.png">
